### PR TITLE
Add Jest testing infrastructure

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,11 @@
+# Backend
+
+## Running Tests
+
+Install dependencies and run:
+
+```bash
+npm test
+```
+
+This executes Jest with Supertest to test the API endpoints.

--- a/backend/app.js
+++ b/backend/app.js
@@ -1,0 +1,31 @@
+import express from "express";
+import cors from "cors";
+import dotenv from "dotenv";
+import blogRoutes from "./src/routes/blogRoutes.js";
+import dbConnection from "./src/scripts/dbConnection.js";
+import contactRoutes from "./src/routes/contactRoutes.js";
+import authRoutes from "./src/routes/authRoutes.js";
+
+dotenv.config();
+
+const app = express();
+app.use(
+  cors({
+    origin: [
+      "http://localhost:5173",
+      "https://2nomaden.netlify.app",
+    ],
+    credentials: true,
+  })
+);
+app.use(express.json());
+
+if (process.env.NODE_ENV !== "test") {
+  dbConnection();
+}
+
+app.use("/api/blogs", blogRoutes);
+app.use("/api/contact", contactRoutes);
+app.use("/api/auth", authRoutes);
+
+export default app;

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,3 @@
+export default {
+  testEnvironment: 'node'
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "start": "node server.js",
-    "dev": "nodemon --env-file=.env server.js --quiet"
+    "dev": "nodemon --env-file=.env server.js --quiet",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "keywords": [],
   "author": "",
@@ -19,5 +20,9 @@
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.13.2",
     "nodemailer": "^6.10.1"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
   }
 }

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,35 +1,5 @@
-// 📁 server.js
-import express from "express";
-import mongoose from "mongoose";
-import cors from "cors";
-import dotenv from "dotenv";
-import nodemailer from "nodemailer";
-import blogRoutes from "./src/routes/blogRoutes.js";
-import dbConnection from "./src/scripts/dbConnection.js";
-import contactRoutes from "./src/routes/contactRoutes.js";
-import authRoutes from "./src/routes/authRoutes.js";
-
-// Env değişkenlerini oku
-dotenv.config();
-
-const app = express();
-app.use(
-  cors({
-    origin: [
-      "http://localhost:5173", // geliştirme ortamı
-      "https://2nomaden.netlify.app", // canlı Netlify frontend
-    ],
-    credentials: true,
-  })
-);
-app.use(express.json());
-
-dbConnection();
-
-//Routes
-app.use("/api/blogs", blogRoutes);
-app.use("/api/contact", contactRoutes);
-app.use("/api/auth", authRoutes);
+// server.js
+import app from './app.js';
 
 const PORT = process.env.PORT || 5000;
 app.listen(PORT, () =>

--- a/backend/tests/blogRoutes.test.js
+++ b/backend/tests/blogRoutes.test.js
@@ -1,0 +1,19 @@
+process.env.NODE_ENV = 'test';
+import request from 'supertest';
+import app from '../app.js';
+import Blog from '../src/models/Blog.js';
+
+describe('Blog routes', () => {
+  beforeAll(() => {
+    jest.spyOn(Blog, 'find').mockResolvedValue([]);
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('GET /api/blogs returns 200', async () => {
+    const res = await request(app).get('/api/blogs');
+    expect(res.statusCode).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary
- export Express `app` in a new `app.js`
- update `server.js` to use the exported `app`
- add Jest configuration and Supertest dev dependencies
- implement a basic integration test for `/api/blogs`
- document test instructions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68594d43837483249154093a817a8da2